### PR TITLE
AssertJ inspection update

### DIFF
--- a/plugin/src/main/java/consulo/junit/inspection/AssertJAssertionsConverterInspection.java
+++ b/plugin/src/main/java/consulo/junit/inspection/AssertJAssertionsConverterInspection.java
@@ -66,7 +66,7 @@ public class AssertJAssertionsConverterInspection extends BaseJavaBatchLocalInsp
 
     @Override
     public boolean isEnabledByDefault() {
-        return true;
+        return false;
     }
 
     @Nonnull

--- a/plugin/src/main/resources/LOCALIZE-LIB/en_US/consulo.junit.JUnitLocalize.yaml
+++ b/plugin/src/main/resources/LOCALIZE-LIB/en_US/consulo.junit.JUnitLocalize.yaml
@@ -3,7 +3,7 @@ junit.configuration.name:
 junit.configuration.description:
   text: JUnit test configuration
 inspections.migrate.assert.to.assertj.name:
-  text: "JUnit assertion can be 'assertThat()' call"
+  text: "AssertJ's 'assertThat' may be used instead of JUnit assertions"
 inspections.migrate.assert.to.assertj.static.import.option:
   text: "Statically import AssertJ's methods"
 inspections.migrate.assert.to.assertj.description:

--- a/plugin/src/main/resources/inspectionDescriptions/AssertJAssertionsConverter.html
+++ b/plugin/src/main/resources/inspectionDescriptions/AssertJAssertionsConverter.html
@@ -1,0 +1,35 @@
+<html>
+    <body>
+        Reports calls to <code>Assert.assertEquals()</code>, <code>Assert.assertTrue()</code>, etc. methods
+        which can be migrated to AssertJ's self-describing <code>Assertions.assertThat()</code> chain calls.
+        <p>For example:</p>
+        <pre><code lang="java">
+    public class SubstantialTest {
+        @Test
+        public void test() {
+            assertTrue("Foobar" instanceof String);
+            assertFalse(new HashMap().size() > 1);
+            assertEquals("foo", "foobar".substring(0, 3));
+            assertNull(null, "Null must be null");
+            assertNotNull(new Object());
+        }
+    }
+        </code></pre>
+        <p>A quick-fix is provided to perform the migration:</p>
+        <pre><code lang="java">
+    public class SubstantialTest {
+        @Test
+        public void testContents(Collection&lt;String&gt; c, String s) {
+            assertThat("Foobar").isInstanceOf(String.class);
+            assertThat(new HashMap()).hasSizeLessThanOrEqualTo(1);
+            assertThat("foobar".substring(0, 3)).isEqualTo("foo");
+            assertThat(null).as("Null must be null").isNull();
+            assertThat(new Object()).isNotNull();
+        }
+    }
+        </code></pre>
+        <!-- tooltip end -->
+        <p>This inspection requires that the AssertJ library is available on the classpath.
+        <p>Use the <b>Statically import AssertJ's methods</b> option to specify if you want the quick-fix to statically import the AssertJ methods.
+    </body>
+</html>

--- a/plugin/src/test/resources/AssertJAssertionsConverterInspection.txt
+++ b/plugin/src/test/resources/AssertJAssertionsConverterInspection.txt
@@ -1,0 +1,44 @@
+assertEquals("foo", "foobar".substring(0, 3));
+assertEquals("foo", "foobar".substring(0, 3), "Strings should be empty");
+
+assertArrayEquals(new int[]{1, 2, 3}, new int[]{1, 2, 3});
+assertArrayEquals(new int[]{1, 2, 3}, new int[]{1, 2, 3}, "Arrays should be equal");
+
+assertNotEquals(new Object(), new Object());
+assertNotEquals(new Object(), new Object(), "Objects should be non-equal");
+
+assertEquals(0, new HashSet().size());
+assertEquals(0, new HashSet().size(), "Set should have zero size");
+
+int x = 5;
+assertFalse(x == 0);
+assertFalse(x == 0, "X should not be empty");
+assertTrue(x != 0);
+assertTrue(x > 0);
+assertTrue(x >= 0);
+assertFalse(x < 0);
+assertFalse(x <= 0);
+
+assertTrue("Foobar" instanceof String);
+assertTrue("Foobar" instanceof String, "Expecting String");
+
+assertTrue(new HashSet().isEmpty());
+assertTrue(new ArrayList().isEmpty());
+assertTrue(new HashMap().isEmpty());
+assertTrue(new HashMap().isEmpty(), "Map should be empty");
+
+assertTrue(new HashSet().size() == 0);
+assertTrue(new HashSet().size() == 0, "Set should have zero size");
+assertFalse(new ArrayList().size() > 1);
+assertFalse(new ArrayList().size() >= 1);
+assertTrue(new HashMap().size() < 1);
+assertTrue(new HashMap().size() <= 1);
+
+assertNull((Object) null);
+assertNull((Object) null, "Should be null");
+
+assertNotNull(new Object());
+assertNotNull(new Object(), "Should not be null");
+
+assertThrows(RuntimeException.class, () -> { throw new RuntimeException();});
+assertThrows(RuntimeException.class, () -> { throw new RuntimeException();}, "Should throw RuntimeException");


### PR DESCRIPTION
Inspection is disabled by default (adding AssertJ library doesn't always mean immediate migration to assertThat). Inspection name in settings now mentions "AssertJ". Inspection description added. Test data stored in txt file.